### PR TITLE
Fixed typo in text

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,6 @@ request.get(completeUrl, (_, res, body) => {
   idGenerator.write(url, outputDirectory);
   metaGenerator.write(url, parsed, outputDirectory);
 
-  console.log(`Downloaded ${images.length} iamge(s)`);
+  console.log(`Downloaded ${images.length} images(s)`);
   console.log('Completed ✅');
 });


### PR DESCRIPTION
I want to ask you, why don't you just use Bahasa Indonesia as a whole? I mean come on, who uses Shopee and Tokopedia if not Indonesians?